### PR TITLE
fix block drop and break

### DIFF
--- a/assets/depletingores/blocktypes/depletingore.json
+++ b/assets/depletingores/blocktypes/depletingore.json
@@ -1,6 +1,8 @@
 {
-  "blockmaterial": "stone",
   "code": "depletingore",
+  "class": "depletingore",
+  "entityclass": "depletingore",
+  "blockmaterial": "stone",
   "creativeinventory": {
     "general": [
       "*"
@@ -8,7 +10,6 @@
   },
   "drawtype": "cube",
   "drops": [],
-  "entityclass": "depletingore",
   "resistance": 3.5,
   "sounds": {
     "place": "game:block/anvil",

--- a/depletingores.csproj
+++ b/depletingores.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\blockEntity\DepletingOreEntity.cs" />
+    <Compile Include="src\block\DepletingOreBlock.cs" />
     <Compile Include="src\DepletingOresSystem.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/DepletingOresSystem.cs
+++ b/src/DepletingOresSystem.cs
@@ -1,4 +1,5 @@
-﻿using depletingores.src.blockEntity;
+﻿using depletingores.src.block;
+using depletingores.src.blockEntity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,6 +18,7 @@ namespace depletingores.src
         public override void Start(ICoreAPI api)
         {
             base.Start(api);
+            api.RegisterBlockClass("depletingore", typeof(DepletingOreBlock));
             api.RegisterBlockEntityClass("depletingore", typeof(DepletingOreEntity));
         }
 

--- a/src/block/DepletingOreBlock.cs
+++ b/src/block/DepletingOreBlock.cs
@@ -1,0 +1,58 @@
+﻿using depletingores.src.blockEntity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent;
+
+namespace depletingores.src.block
+{
+    // TODO: Make class extend BlockOre instead of Block.
+    public class DepletingOreBlock : Block
+    {
+        public override void OnBlockBroken(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, float dropQuantityMultiplier = 1)
+        {
+            DepletingOreEntity entity = (DepletingOreEntity)world.BlockAccessor.GetBlockEntity(pos);
+
+            if (entity.CurrentQuantity != 0)
+            {
+                //Generate and drop loot
+                var itemToDrop = GenerateDropItem(entity.QuantityPercentageRemaining, world);
+                var itemStackDrop = new ItemStack(itemToDrop);
+                world.SpawnItemEntity(itemStackDrop, pos.ToVec3d());
+
+                entity.CurrentQuantity--;
+            }
+            else
+            {
+                //Allow the block to get destroyed.
+                base.OnBlockBroken(world, pos, byPlayer, dropQuantityMultiplier);
+            }
+
+        }
+
+        // TODO: Generate item drops based on block type. 
+        // e.g. ore-rich-bismuthinite-andesite -> 100% = rich-bismuthinite, 50% = medium-bismuthinite, 25% = poor-bismuthinite.
+
+        private static List<Item> lootTable;
+        public Item GenerateDropItem(double quantityPercentageRemaining, IWorldAccessor world)
+        {
+            if (lootTable == null)
+            {
+                lootTable = new List<Item> {
+                    world.GetItem(new AssetLocation("pickaxe-copper")),
+                    world.GetItem(new AssetLocation("pickaxe-iron")),
+                    world.GetItem(new AssetLocation("pickaxe-gold"))
+                };
+            }
+
+            // TODO: Fix weird drop distribution.
+            int index = (int)Math.Round((lootTable.Count - 1) * quantityPercentageRemaining);
+            return lootTable[index];
+        }
+    }
+}

--- a/src/blockEntity/DepletingOreEntity.cs
+++ b/src/blockEntity/DepletingOreEntity.cs
@@ -14,7 +14,6 @@ namespace depletingores.src.blockEntity
 {
     public class DepletingOreEntity : BlockEntity
     {
-        private List<Item> lootTable;
         public int BaseQuantity { get; internal set; }
         public int CurrentQuantity { get; internal set; }
         public double QuantityPercentageRemaining
@@ -22,53 +21,18 @@ namespace depletingores.src.blockEntity
             get { return (double)CurrentQuantity / (double)BaseQuantity; }
         }
 
-        private IWorldAccessor _world;
-
         public override void Initialize(ICoreAPI api)
         {
             base.Initialize(api);
-            _world = api.World;
-            BaseQuantity = 10;
+            BaseQuantity = GetBaseQuantity();
             CurrentQuantity = BaseQuantity;
         }
 
-        public Item GenerateItem(double quantityPercentageRemaining, IWorldAccessor world)
+        // TODO: Choose base quantity based on more factors. 
+        // e.i. Block type, Position in cluster(At egde vs. Towards center).
+        private int GetBaseQuantity()
         {
-            if (lootTable == null)
-            {
-                lootTable = new List<Item> {
-                    world.GetItem(new AssetLocation("pickaxe-copper")),
-                    world.GetItem(new AssetLocation("pickaxe-iron")),
-                    world.GetItem(new AssetLocation("pickaxe-gold"))
-                };
-            }
-
-            int index = (int)Math.Round((lootTable.Count - 1) * quantityPercentageRemaining);
-            return lootTable[index];
-        }
-
-        public override void OnBlockBroken()
-        {
-            base.OnBlockBroken();
-            //Debug message to chat
-            if (_world.Api.Side.IsServer())
-            {
-                var sapi = _world.Api as ICoreServerAPI;
-                sapi.BroadcastMessageToAllGroups(string.Format("a:{0} b:{1} c:{2}", BaseQuantity, CurrentQuantity, QuantityPercentageRemaining), EnumChatType.AllGroups);
-            }
-
-            //Generate and drop loot
-            var itemToDrop = GenerateItem(QuantityPercentageRemaining, _world);
-            var itemStackDrop = new ItemStack(itemToDrop);
-            _world.SpawnItemEntity(itemStackDrop, this.Pos.ToVec3d());
-            CurrentQuantity--;
-
-            //Replace destroyed block if quantity is above zero. (Alternative: The block should be destroyed.)
-            if (CurrentQuantity > 0)
-            {
-                //TODO|WARNING: This is not preventing the blocks default behavior of getting destroyed and therefore deleting this entity..
-                _world.BlockAccessor.ExchangeBlock(Block.Id, this.Pos);
-            }
+            return 10;
         }
     }
 


### PR DESCRIPTION
This fix enables the block to drop and break when it's quantity has depleted.

Thanks to @tylermcwilliams who figured out how to prevent the block from breaking until the entity quantity has depleted.