### PR TITLE
add ore-graded.json

### DIFF
--- a/assets/depletingores/blocktypes/depletingore.json
+++ b/assets/depletingores/blocktypes/depletingore.json
@@ -1,7 +1,7 @@
 {
   "code": "depletingore",
-  "class": "depletingore",
-  "entityclass": "depletingore",
+  "class": "DepletingOreBlock",
+  "entityclass": "DepletingOreEntity",
   "blockmaterial": "stone",
   "creativeinventory": {
     "general": [

--- a/assets/depletingores/patches/ore-graded.json
+++ b/assets/depletingores/patches/ore-graded.json
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "file": "game:blocktypes/stone/ore-graded",
+    "op": "replace",
+    "path": "/class",
+    "value": "DepletingOreBlock"
+  },
+  {
+    "file": "game:blocktypes/stone/ore-graded",
+    "op": "add",
+    "path": "/entityclass",
+    "value": "DepletingOreEntity"
+  }
+]

--- a/depletingores.csproj
+++ b/depletingores.csproj
@@ -68,11 +68,13 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="assets\depletingores\blocktypes\depletingore.json" />
+    <None Include="assets\depletingores\patches\ore-graded.json" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\blockEntity\DepletingOreEntity.cs" />
     <Compile Include="src\block\DepletingOreBlock.cs" />
     <Compile Include="src\DepletingOresSystem.cs" />
+    <Compile Include="src\ModContext.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/modinfo.json
+++ b/modinfo.json
@@ -3,7 +3,7 @@
   "modid": "depletingores",
   "name": "Depleting Ores",
   "author": "Jacker Deluxe",
-  "description": "A vintage story mod that implements ore blocks that have an infinite yield that deplete in quality when mined.",
+  "description": "A vintage story mod that implements ore blocks that have an infinite(or specified) yield that deplete in quality when mined.",
   "version": "1.0.0",
   "dependency": {
     "game": "",

--- a/src/DepletingOresSystem.cs
+++ b/src/DepletingOresSystem.cs
@@ -18,8 +18,8 @@ namespace depletingores.src
         public override void Start(ICoreAPI api)
         {
             base.Start(api);
-            api.RegisterBlockClass("depletingore", typeof(DepletingOreBlock));
-            api.RegisterBlockEntityClass("depletingore", typeof(DepletingOreEntity));
+            api.RegisterBlockClass(ModContext.ClassNames.DepletingOreBlock, typeof(DepletingOreBlock));
+            api.RegisterBlockEntityClass(ModContext.ClassNames.DepletingOreEntity, typeof(DepletingOreEntity));
         }
 
     }

--- a/src/ModContext.cs
+++ b/src/ModContext.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace depletingores.src
+{
+    public static class ModContext
+    {
+        public static class ClassNames
+        {
+            public const string DepletingOreBlock = "DepletingOreBlock";
+            public const string DepletingOreEntity = "DepletingOreEntity";
+        }
+    }
+}

--- a/src/blockEntity/DepletingOreEntity.cs
+++ b/src/blockEntity/DepletingOreEntity.cs
@@ -32,7 +32,7 @@ namespace depletingores.src.blockEntity
         // e.i. Block type, Position in cluster(At egde vs. Towards center).
         private int GetBaseQuantity()
         {
-            return 10;
+            return 5;
         }
     }
 


### PR DESCRIPTION
The json patch ore-graded.json sets the class and entityclass of game:graded-ore to DepletingOreBlock and DepletingOreEntity, thereby extending the durability of the graded-ore blocks to our specified quantity values.